### PR TITLE
Fix broken link for PR template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ The process described here has several goals:
 
 Please follow these steps to have your contribution considered by the maintainers:
 
-1. Follow all instructions in [the template](PULL_REQUEST_TEMPLATE.md)
+1. Follow all instructions in the template, this will auto-populate when you open a Pull Request. The template can be seen [here](https://github.com/Public-Health-Scotland/knowledge-base/blob/main/.github/pull_request_template.md).
 2. Follow the [styleguides](#styleguides)
 
 While the prerequisites above must be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.


### PR DESCRIPTION
## Pull Request Details

**Type**: Bug 

### Identify the Issue

Fixes #22 - contributing page, broken link

### Description of the Change

The link was a relative link but as the document was in a sub-folder this doesn't work. A static link was used to replace this, and some further text to describe the contents.

#### Possible Drawbacks

Any future changes to the location of files will break the link. 

#### Verification Process

Tested

### Release Notes

N/A - documentation